### PR TITLE
fix: removed local replace from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,4 @@ require (
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43 // indirect
 )
 
-replace github.com/ionos-cloud/ionos-cloud-sdk-go/v5 => /Users/florin/work/code/ionos-cloud/ionos-cloud-sdk-go
 go 1.13


### PR DESCRIPTION
# Motivation

Have a clean upstream go.mod to not run into dependency issues

# Description

The current replace directive points to a local folder which is not usable for anyone else then the initial developer that added the replace directive